### PR TITLE
Update database migration process to ensure schema consistency

### DIFF
--- a/.replit
+++ b/.replit
@@ -14,6 +14,10 @@ run = ["npm", "run", "start"]
 localPort = 5000
 externalPort = 80
 
+[[ports]]
+localPort = 38463
+externalPort = 3000
+
 [env]
 PORT = "5000"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,33 +12,23 @@ RUN npm ci
 # Copier le reste du code source
 COPY . .
 
-# Générer les migrations de base de données
-RUN npx drizzle-kit generate || echo "No schema changes to generate"
-
-# Créer le dossier drizzle s'il n'existe pas
-RUN mkdir -p drizzle
-
 # Build du frontend et backend
 RUN npm run build
-
-# Compiler le script de migration
-RUN npx esbuild server/migrate.ts --platform=node --packages=external --bundle --format=esm --outfile=dist/migrate.js
 
 # Étape 2: Image de production
 FROM node:20-alpine
 
 WORKDIR /app
 
-# Installer uniquement les dépendances de production
+# Installer toutes les dépendances (drizzle-kit est nécessaire pour push)
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm ci
 
 # Copier les fichiers buildés et le code serveur
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/server ./server
 COPY --from=builder /app/shared ./shared
 COPY --from=builder /app/drizzle.config.ts ./
-COPY --from=builder /app/drizzle ./drizzle
 
 # Exposer le port 5555
 EXPOSE 5555

--- a/attached_assets/Pasted-Running-database-migrations-Migration-failed-Error-Can-t-find-meta-journal-json-file--1759330330576_1759330330576.txt
+++ b/attached_assets/Pasted-Running-database-migrations-Migration-failed-Error-Can-t-find-meta-journal-json-file--1759330330576_1759330330576.txt
@@ -1,0 +1,71 @@
+Running database migrations...
+
+Migration failed: Error: Can't find meta/_journal.json file
+
+    at readMigrationFiles (file:///app/node_modules/drizzle-orm/migrator.js:8:11)
+
+    at migrate (file:///app/node_modules/drizzle-orm/node-postgres/migrator.js:3:22)
+
+    at runMigrations (file:///app/dist/migrate.js:228:11)
+
+    at file:///app/dist/migrate.js:238:1
+
+    at ModuleJob.run (node:internal/modules/esm/module_job:325:25)
+
+    at async ModuleLoader.import (node:internal/modules/esm/loader:606:24)
+
+    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
+
+Running database migrations...
+
+Migration failed: Error: Can't find meta/_journal.json file
+
+    at readMigrationFiles (file:///app/node_modules/drizzle-orm/migrator.js:8:11)
+
+    at migrate (file:///app/node_modules/drizzle-orm/node-postgres/migrator.js:3:22)
+
+    at runMigrations (file:///app/dist/migrate.js:228:11)
+
+    at file:///app/dist/migrate.js:238:1
+
+    at ModuleJob.run (node:internal/modules/esm/module_job:325:25)
+
+    at async ModuleLoader.import (node:internal/modules/esm/loader:606:24)
+
+    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
+
+Running database migrations...
+
+Migration failed: Error: Can't find meta/_journal.json file
+
+    at readMigrationFiles (file:///app/node_modules/drizzle-orm/migrator.js:8:11)
+
+    at migrate (file:///app/node_modules/drizzle-orm/node-postgres/migrator.js:3:22)
+
+    at runMigrations (file:///app/dist/migrate.js:228:11)
+
+    at file:///app/dist/migrate.js:238:1
+
+    at ModuleJob.run (node:internal/modules/esm/module_job:325:25)
+
+    at async ModuleLoader.import (node:internal/modules/esm/loader:606:24)
+
+    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
+
+Running database migrations...
+
+Migration failed: Error: Can't find meta/_journal.json file
+
+    at readMigrationFiles (file:///app/node_modules/drizzle-orm/migrator.js:8:11)
+
+    at migrate (file:///app/node_modules/drizzle-orm/node-postgres/migrator.js:3:22)
+
+    at runMigrations (file:///app/dist/migrate.js:228:11)
+
+    at file:///app/dist/migrate.js:238:1
+
+    at ModuleJob.run (node:internal/modules/esm/module_job:325:25)
+
+    at async ModuleLoader.import (node:internal/modules/esm/loader:606:24)
+
+    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    command: sh -c "node dist/migrate.js && npm run start"
+    command: sh -c "npx drizzle-kit push --force && npm run start"
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Modify Dockerfile and docker-compose.yml to use `npx drizzle-kit push --force` for database migrations, resolving "Can't find meta/_journal.json" errors and ensuring correct schema application.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: ae4037a0-2a6f-4530-9bac-79b543286bda
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/397bca8c-984f-43ff-841a-10897aeb8140/ae4037a0-2a6f-4530-9bac-79b543286bda/Yxw6kHP