### PR TITLE
Preserve Cloudinary configuration on settings update

### DIFF
--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -55,18 +55,28 @@ export default function Settings() {
   const hasExistingConfig = !!openrouterConfig;
 
   const saveCloudinaryMutation = useMutation({
-    mutationFn: () => 
-      apiRequest('POST', '/api/cloudinary/config', {
+    mutationFn: () => {
+      const payload: any = {
         cloudName,
-        apiKey,
-        apiSecret,
-      }),
+      };
+      
+      // N'inclure apiKey et apiSecret que s'ils ne sont pas vides
+      if (apiKey && apiKey.trim() !== "") {
+        payload.apiKey = apiKey;
+      }
+      if (apiSecret && apiSecret.trim() !== "") {
+        payload.apiSecret = apiSecret;
+      }
+      
+      return apiRequest('POST', '/api/cloudinary/config', payload);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/cloudinary/config'] });
       toast({
         title: "Configuration sauvegardée",
         description: "Vos paramètres Cloudinary ont été enregistrés",
       });
+      setApiKey(""); // Clear the API key after saving
       setApiSecret(""); // Clear the secret after saving
     },
     onError: () => {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -230,6 +230,11 @@ export const updateOpenrouterConfigSchema = insertOpenrouterConfigSchema.partial
   apiKey: true,
 });
 
+export const updateCloudinaryConfigSchema = insertCloudinaryConfigSchema.partial({
+  apiKey: true,
+  apiSecret: true,
+});
+
 // Types
 export type User = typeof users.$inferSelect;
 export type InsertUser = z.infer<typeof insertUserSchema>;
@@ -251,8 +256,10 @@ export type InsertAiGeneration = z.infer<typeof insertAiGenerationSchema>;
 
 export type CloudinaryConfig = typeof cloudinaryConfig.$inferSelect;
 export type InsertCloudinaryConfig = z.infer<typeof insertCloudinaryConfigSchema>;
+export type UpdateCloudinaryConfig = z.infer<typeof updateCloudinaryConfigSchema>;
 
 export type OpenrouterConfig = typeof openrouterConfig.$inferSelect;
 export type InsertOpenrouterConfig = z.infer<typeof insertOpenrouterConfigSchema>;
+export type UpdateOpenrouterConfig = z.infer<typeof updateOpenrouterConfigSchema>;
 
 export type PostMedia = typeof postMedia.$inferSelect;


### PR DESCRIPTION
Modify Cloudinary configuration endpoint to allow partial updates and preserve existing API keys and secrets when not explicitly provided, and clear input fields on successful save.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: ae4037a0-2a6f-4530-9bac-79b543286bda
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/397bca8c-984f-43ff-841a-10897aeb8140/ae4037a0-2a6f-4530-9bac-79b543286bda/sEXz3DF