### PR TITLE
fix(openrouter): resolve AI generation 401/404 errors

### DIFF
--- a/server/services/openrouter.ts
+++ b/server/services/openrouter.ts
@@ -26,16 +26,23 @@ export class OpenRouterService {
       throw new Error('Configuration OpenRouter non trouvée. Veuillez demander à un administrateur de configurer OpenRouter dans les Paramètres.');
     }
 
+    if (!config.apiKey || !config.apiKey.trim()) {
+      throw new Error('Clé API OpenRouter manquante ou vide en base de données. Veuillez la ressaisir dans les Paramètres.');
+    }
+
     const prompt = this.buildPrompt(productInfo, config.systemPrompt);
-    
+
     // Use provided model or fall back to config model
     const modelToUse = modelOverride || config.model;
+
+    const keyPreview = `${config.apiKey.slice(0, 10)}...(len=${config.apiKey.length})`;
+    console.log(`[OpenRouter] Generating with model="${modelToUse}" key=${keyPreview} configUserId=${config.userId}`);
 
     try {
       const response = await fetch(this.baseUrl, {
         method: "POST",
         headers: {
-          "Authorization": `Bearer ${config.apiKey}`,
+          "Authorization": `Bearer ${config.apiKey.trim()}`,
           "Content-Type": "application/json",
           "HTTP-Referer": process.env.APP_URL || "http://localhost:5555",
           "X-Title": "Social Flow"

--- a/server/services/openrouter.ts
+++ b/server/services/openrouter.ts
@@ -12,6 +12,7 @@ interface GeneratedText {
   characterCount: number;
 }
 
+import crypto from 'crypto';
 import { storage } from '../storage';
 
 export class OpenRouterService {
@@ -35,8 +36,8 @@ export class OpenRouterService {
     // Use provided model or fall back to config model
     const modelToUse = modelOverride || config.model;
 
-    const keyPreview = `${config.apiKey.slice(0, 10)}...(len=${config.apiKey.length})`;
-    console.log(`[OpenRouter] Generating with model="${modelToUse}" key=${keyPreview} configUserId=${config.userId}`);
+    const keyFingerprint = crypto.createHash('sha256').update(config.apiKey).digest('hex').slice(0, 8);
+    console.log(`[OpenRouter] Generating with model="${modelToUse}" keyFingerprint=${keyFingerprint} keyLength=${config.apiKey.length} configUserId=${config.userId}`);
 
     try {
       const response = await fetch(this.baseUrl, {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -394,7 +394,7 @@ export const insertOpenrouterConfigSchema = createInsertSchema(openrouterConfig)
   createdAt: true,
   updatedAt: true,
 }).extend({
-  apiKey: z.string().min(1, "La clé API ne peut pas être vide"),
+  apiKey: z.string().trim().min(1, "La clé API ne peut pas être vide"),
 });
 
 export const updateOpenrouterConfigSchema = insertOpenrouterConfigSchema.partial({


### PR DESCRIPTION
## Summary
- Fix `generatePostText` ignoring the requesting user's `userId` and always reading an arbitrary config row via `getAnyOpenrouterConfig()` (`LIMIT 1`, no `ORDER BY`), which could shadow a model choice saved in Settings with a stale config row. Now the user's own saved config is preferred, falling back to the most recently updated shared config, made deterministic with `ORDER BY updatedAt DESC`.
- Replace the retired `anthropic/claude-3.5-sonnet` default (OpenRouter now returns `404 No endpoints found` for it) with a currently live model slug (`anthropic/claude-sonnet-4.5`) across the schema default, both Settings pages, the AI chat component, and the Docker migration SQL.
- Trim the OpenRouter API key on save (schema level) and on use, since a trailing newline/space from copy-paste produces OpenRouter's `401 Missing Authentication header` — a message indistinguishable from a genuinely missing key. Fail fast with a clear error if the stored key is empty, and log a masked key preview + model before each generation call for easier diagnosis.

## Test plan
- [x] Verified via direct `curl` against `https://openrouter.ai/api/v1/models` that `anthropic/claude-3.5-sonnet` is no longer listed / returns 404.
- [x] Verified via direct `curl` against OpenRouter's chat completions endpoint that a malformed/whitespace-polluted bearer token produces the same `401 Missing Authentication header` as a fully empty header, confirming the root cause of the second reported error.
- [ ] User to rebuild/redeploy the Docker container from this branch, re-save the OpenRouter API key in Settings, and confirm AI text generation succeeds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L7CP9cobjeRHSiTQm4mvXr)_